### PR TITLE
urlToOpts should include protocol to support simply getting https

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ function urlToOpts (u) {
   return {
     hostname: loc.hostname,
     port: loc.port,
-    path: loc.path
+    path: loc.path,
+    protocol: loc.protocol
   }
 }
 


### PR DESCRIPTION
urlToOpts is not including protocol so

```
get('https://myurl.com',
        function(err, getResponse) {
```

did not work since it was still trying http.
