### PR TITLE
use the `unzip-response` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/feross/simple-get/issues"
   },
   "dependencies": {
-    "once": "^1.3.1"
+    "once": "^1.3.1",
+    "unzip-response": "^1.0.0"
   },
   "devDependencies": {
     "concat-stream": "^1.4.7",


### PR DESCRIPTION
It will convert it to an unzip stream if needed, otherwise return the original response stream.

https://github.com/sindresorhus/unzip-response

We had almost the exact thing in [`got`](https://github.com/sindresorhus/got) so I made it a module.

-

This also makes the `All this in < 100 lines of code.` statement true again ;)