### PR TITLE
don't modify the user-supplied object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ var https = require('https')
 var once = require('once')
 var url = require('url')
 var unzipResponse = require('unzip-response')
+var objectAssign = require('object-assign')
 
 function simpleGet (opts, cb) {
-  if (typeof opts === 'string') opts = { url: opts }
+  opts = typeof opts === 'string' ? { url: opts } : objectAssign({}, opts)
   cb = once(cb)
 
   // Follow redirects

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/feross/simple-get/issues"
   },
   "dependencies": {
+    "object-assign": "^3.0.0",
     "once": "^1.3.1",
     "unzip-response": "^1.0.0"
   },


### PR DESCRIPTION
As a general rule this is almost always bad and can cause weird bugs. If the user has the the options object in a variable then calls simpleGet, the second time simpleGet is called it will use the already modified object and have different behaviour.