### PR TITLE
Use correct HTTP headers on json requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,14 @@ function simpleGet (opts, cb) {
 
   if (opts.url) parseOptsUrl(opts)
   if (opts.headers == null) opts.headers = {}
-  if (opts.json) opts.headers['content-type'] = 'application/json'
   if (opts.maxRedirects == null) opts.maxRedirects = 10
 
   var body = opts.json ? JSON.stringify(opts.body) : opts.body
   opts.body = undefined
   if (body && !opts.method) opts.method = 'POST'
+
+  if (opts.json) opts.headers['accept'] = 'application/json'
+  if (opts.json && opts.method === 'POST') opts.headers['content-type'] = 'application/json'
 
   // Request gzip/deflate
   var customAcceptEncoding = Object.keys(opts.headers).some(function (h) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -389,7 +389,7 @@ test('simple get json', function (t) {
 
   var server = http.createServer(function (req, res) {
     t.equal(req.url, '/path')
-    t.equal(req.headers['content-type'], 'application/json')
+    t.equal(req.headers['accept'], 'application/json')
     res.statusCode = 200
     res.end('{"message":"response"}')
   })
@@ -454,10 +454,11 @@ test('get.concat json error', function (t) {
 })
 
 test('post (json body)', function (t) {
-  t.plan(4)
+  t.plan(5)
 
   var server = http.createServer(function (req, res) {
     t.equal(req.method, 'POST')
+    t.equal(req.headers['content-type'], 'application/json')
     res.statusCode = 200
     req.pipe(res)
   })


### PR DESCRIPTION
GET should use `accept` header and POST should add `content-type` header for JSON handling.