### PR TITLE
Fix content-length header with utf-8 text

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function simpleGet (opts, cb) {
 
   if (opts.json) opts.headers.accept = 'application/json'
   if (opts.json && body) opts.headers['content-type'] = 'application/json'
-  if (body) opts.headers['Content-Length'] = body.length
+  if (body) opts.headers['Content-Length'] = Buffer.byteLength(body)
 
   // Request gzip/deflate
   var customAcceptEncoding = Object.keys(opts.headers).some(function (h) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -317,6 +317,32 @@ test('post (text body)', function (t) {
   })
 })
 
+test('post (utf-8 text body)', function (t) {
+  t.plan(4)
+
+  var server = http.createServer(function (req, res) {
+    t.equal(req.method, 'POST')
+    res.statusCode = 200
+    req.pipe(res)
+  })
+
+  server.listen(0, function () {
+    var port = server.address().port
+    var opts = {
+      url: 'http://localhost:' + port,
+      body: 'jedan dva tri četiri'
+    }
+    get.post(opts, function (err, res) {
+      t.error(err)
+      t.equal(res.statusCode, 200)
+      res.pipe(concat(function (data) {
+        t.equal(data.toString(), 'jedan dva tri četiri')
+        server.close()
+      }))
+    })
+  })
+})
+
 test('post (buffer body)', function (t) {
   t.plan(4)
 


### PR DESCRIPTION
Use Buffer.byteLength() for content-length headers to get the length in bytes as opposed to the length in characters.