### PR TITLE
Do not modify opts.headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function simpleGet (opts, cb) {
   cb = once(cb)
 
   if (opts.url) parseOptsUrl(opts)
-  if (opts.headers == null) opts.headers = {}
+  opts.headers = extend(opts.headers)
   if (opts.maxRedirects == null) opts.maxRedirects = 10
 
   var body = opts.body


### PR DESCRIPTION
Hey,

I was getting some socket hang up errors in my code. Because I reused the headers object that I passed to `simple-get`.

```js
const headers = {...}
get({headers: headers, method: 'POST', url: 'http...', body: '.....'}, function () {
  // the next request fails, because it has a content-length that it shouldn't have
   get({headers: headers, method: 'GET', url: 'http... '})
})
```

This PR makes a copy of `opts.headers` to make sure that the original it will not be modified.