### PR TITLE
rewrite redirected POST request to a GET

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,13 @@ function simpleGet (opts, cb) {
       opts.url = res.headers.location
       res.resume() // Discard response
 
+      // move redirected POST requests to GET (https://tools.ietf.org/html/rfc7231#section-6.4)
+      if ((res.statusCode === 301 || res.statusCode === 302) && opts.method === 'POST') {
+        opts.method = 'GET'
+        delete opts.headers['content-length']
+        delete opts.headers['content-type']
+      }
+
       if (opts.maxRedirects > 0) {
         opts.maxRedirects -= 1
         simpleGet(opts, cb)


### PR DESCRIPTION
Browsers rewrite 301 and 301 redirects for POST requests to GET. This is also specified in https://tools.ietf.org/html/rfc7231\#section-6.4.2 now.

Our current implementation forgets to pass the body to the redirect on POST anyway. So it will hang, since it's only passing the `content-length`, but not the body.

I suggest to implement the browser's behavior as this is what most people would expect.