### PR TITLE
[wip] return a promise when there is no callback in concat

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ get.concat('http://example.com', function (err, res, data) {
 })
 ```
 
+or with async/await
+
+```js
+const get = require('simple-get')
+
+async function run () {
+  const { res, data } = await get.concat('http://example.com')
+  console.log(res.statusCode) // 200
+  console.log(data) // Buffer('this is the server response')
+  })
+}
+
+run().then(({ data } => console.log(data.toString()))
+```
+
 ### POST, PUT, PATCH, HEAD, DELETE support
 
 For `POST`, call `get.post` or use option `{ method: 'POST' }`.

--- a/index.js
+++ b/index.js
@@ -74,6 +74,13 @@ function simpleGet (opts, cb) {
 }
 
 simpleGet.concat = (opts, cb) => {
+  if (cb) return _concat(opts, cb)
+  return new Promise((resolve, reject) => {
+    _concat(opts, (err, res, data) => err ? reject(err) : resolve({ res, data }))
+  })
+}
+
+function _concat (opts, cb) {
   return simpleGet(opts, (err, res) => {
     if (err) return cb(err)
     concat(res, (err, data) => {

--- a/test/concat.js
+++ b/test/concat.js
@@ -89,3 +89,24 @@ test('get.concat json error', function (t) {
     })
   })
 })
+
+test('get.concat with Promise', function (t) {
+  t.plan(3)
+  var server = http.createServer(function (req, res) {
+    res.statusCode = 200
+    res.end('blah blah blah')
+  })
+
+  server.listen(0, function () {
+    var port = server.address().port
+    get
+      .concat('http://localhost:' + port)
+      .then(({ res, data }) => {
+        t.equal(res.statusCode, 200)
+        t.ok(Buffer.isBuffer(data), '`data` is type buffer')
+        t.equal(data.toString(), 'blah blah blah')
+        server.close()
+      })
+      .catch(t.fail)
+  })
+})


### PR DESCRIPTION
I've added support for async/await during `get.concat()`.

This is a wip, and more intended to discuss rather than a proper direction.

The main concern is on the return type, which is in the form of `{ res, data }`, so it uses a full object instead of positional arguments. This is also the main reason why `util.promisify()` cannot be used with `get.concat()`.

It also make the module pass the > 100 lines :(.

(we can also ship `require('simple-get/promise')` as a second entry point).

