### PR TITLE
remove require('url') in favor of URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
+  - 12
   - 10
-  - 8
-  - 6


### PR DESCRIPTION
Closes #53

This also updates travis to use node versions 12 and 10 for tests.

node 8.x is at EOL [starting December 2019](https://github.com/nodejs/Release#release-schedule).