### PR TITLE
noDecompress option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ get({
 
   // simple-get accepts all options that node.js `http` accepts
   // See: http://nodejs.org/api/http.html#http_http_request_options_callback
+  // Special option `noDecompress` allows to skip response body decompression.
   headers: {
     'user-agent': 'my cool app'
   }

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function simpleGet (opts, cb) {
       else return simpleGet(opts, cb)
     }
 
-    const tryUnzip = typeof decompressResponse === 'function' && opts.method !== 'HEAD'
+    const tryUnzip = !opts.noDecompress && typeof decompressResponse === 'function' && opts.method !== 'HEAD'
     cb(null, tryUnzip ? decompressResponse(res) : res)
   })
   req.on('timeout', () => {


### PR DESCRIPTION
`noDecompress` option allows to skip response body decompression.